### PR TITLE
Add content-based recommendation feature with optional similarity scores

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -8,6 +8,7 @@ import evidence_ds as evidence_ds
 from recommendation_ds import df_catalog
 import streamlit_authenticator as stauth
 from template import mylist_curation_tools  # Import activity function from the other file
+import transparency_tools  # For content-based recommendations + explanation
 
 import yaml  # YAML parser and emitter for Python
 from yaml.loader import SafeLoader  # Loader class for safe YAML loading
@@ -15,10 +16,10 @@ from yaml.loader import SafeLoader  # Loader class for safe YAML loading
 # Configure the layout of the Streamlit page to use a wide format for more space
 st.set_page_config(layout="wide")
 
-st.image("../bbc_demo_streamlite/app/static/bbc_logo.jpg", width=150)  # Adjust width as needed
+st.image("static/bbc_logo.jpg", width=150)  # Adjust width as needed
 
 # Loading the configuration from a YAML file
-with open('app/config.yaml') as file:
+with open('config.yaml') as file:
     config = yaml.load(file, Loader=SafeLoader)
     
 # Initializing the authenticator with the configuration data
@@ -137,6 +138,28 @@ if st.session_state["authentication_status"]:
     # 🔹 Display Recommended Content
     st.title("Accessibility-Aware Recommendations")
     preview(df_catalog)
+
+    #transparency added
+
+    st.subheader("Content Recommender based on your interests")
+
+    user_input = st.text_input("Describe what you're interested in:")
+
+    if user_input:
+        results = transparency_tools.recommend_from_input(user_input, df_catalog)
+
+        show_scores = st.checkbox("Show similarity scores", value=False)
+
+
+        st.markdown("### Recommended for you:")
+        columns = st.columns(5)
+        items = results.to_dict(orient='records')
+        for column, item in zip(columns, items):
+            tile_item(column, item, st.session_state["user_preferences"])
+            if show_scores:
+               with column:
+                st.caption(f"Similarity Score: {round(item['similarity_score'], 3)}")
+
 
     st.subheader('BBC Content ')
 

--- a/app/catalog_ds.py
+++ b/app/catalog_ds.py
@@ -1,7 +1,8 @@
 import pandas as pd
 
 
-df_catalog = pd.read_pickle('../bbc_demo_streamlite/data/bbc_full_dataset.pkl')
+df_catalog = pd.read_pickle('../data/bbc_full_dataset.pkl')
+
 
 
 

--- a/app/recommendation_ds.py
+++ b/app/recommendation_ds.py
@@ -5,7 +5,7 @@ import streamlit as st
 
 
 # Load Dataset (Ensure the correct path to your dataset)
-df_catalog = pd.read_pickle('../bbc_demo_streamlite/data/bbc_full_dataset.pkl')
+df_catalog = pd.read_pickle('../data/bbc_full_dataset.pkl')
 
 if "captions" not in df_catalog.columns:
     df_catalog["captions"] = np.random.choice([True, False], len(df_catalog))

--- a/app/transparency_tools.py
+++ b/app/transparency_tools.py
@@ -1,0 +1,24 @@
+from sklearn.feature_extraction.text import TfidfVectorizer
+from sklearn.metrics.pairwise import cosine_similarity
+
+def recommend_from_input(user_input, df, top_n=5):
+    tfidf = TfidfVectorizer(stop_words='english')
+    tfidf_matrix = tfidf.fit_transform(df['description'])
+
+    user_vec = tfidf.transform([user_input])
+    similarity_scores = cosine_similarity(user_vec, tfidf_matrix).flatten()
+
+    df['similarity_score'] = similarity_scores
+    recommended = df.sort_values(by='similarity_score', ascending=False).head(top_n)
+
+    return recommended
+
+def explain_recommendation():
+    explanation = """
+    ### How Recommendations Are Generated:
+    - We use **TF-IDF (Term Frequency-Inverse Document Frequency)** to convert your input and content descriptions into numerical vectors.
+    - Then we apply **Cosine Similarity** to compare your input with all content.
+    - The top results with highest similarity scores are shown as recommendations.
+    """
+    return explanation
+


### PR DESCRIPTION
This PR adds a content-based recommendation section using TF-IDF and Cosine Similarity.
Users can input keywords to receive personalized suggestions.
They can optionally view similarity scores below each recommended item.
All existing functionality is preserved.

